### PR TITLE
Add enum option to properties

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -122,6 +122,10 @@
                       "description": "Property values must be a multiple of this number. Only relevant for numeric properties.",
                       "type": "number"
                     },
+                    "enum": {
+                      "description": "Property values must be one of these options, given as a JSON Array. Only relevant for string properties.",
+                      "type": "string"
+                    },
                     "readOnly": {
                       "description": "Whether or not this property is read-only.",
                       "type": "boolean"

--- a/manifest.json
+++ b/manifest.json
@@ -124,7 +124,10 @@
                     },
                     "enum": {
                       "description": "Property values must be one of these options, given as a JSON Array. Only relevant for string properties.",
-                      "type": "string"
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "readOnly": {
                       "description": "Whether or not this property is read-only.",

--- a/manifest.json
+++ b/manifest.json
@@ -123,7 +123,7 @@
                       "type": "number"
                     },
                     "enum": {
-                      "description": "Property values must be one of these options, given as a JSON Array. Only relevant for string properties.",
+                      "description": "Property values must be one of these options. Only relevant for string properties.",
                       "type": "array",
                       "items": {
                         "type": "string"

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -1546,13 +1546,8 @@ class VirtualThingsAdapter extends Adapter {
             }
           }
 
-          if (property.type !== 'string') {
+          if (property.type !== 'string' || !Array.isArray(property.enum) || !property.enum.length) {
             delete property.enum;
-          } else {
-            try {
-              property.enum = JSON.parse(property.enum);
-            } catch (ex) { // eslint-disable-line no-empty
-            }
           }
 
           switch (property.type) {

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -1546,7 +1546,11 @@ class VirtualThingsAdapter extends Adapter {
             }
           }
 
-          if (property.type !== 'string' || !Array.isArray(property.enum) || !property.enum.length) {
+          if (
+            property.type !== 'string' ||
+            !Array.isArray(property.enum) ||
+            !property.enum.length
+          ) {
             delete property.enum;
           }
 

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -1545,13 +1545,14 @@ class VirtualThingsAdapter extends Adapter {
               delete property.multipleOf;
             }
           }
-          
+
           if (property.type !== 'string') {
             delete property.enum;
           } else {
             try {
               property.enum = JSON.parse(property.enum);
-            } catch (ex) {}
+            } catch (ex) { // eslint-disable-line no-empty
+            }
           }
 
           switch (property.type) {

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -1545,6 +1545,14 @@ class VirtualThingsAdapter extends Adapter {
               delete property.multipleOf;
             }
           }
+          
+          if (property.type !== 'string') {
+            delete property.enum;
+          } else {
+            try {
+              property.enum = JSON.parse(property.enum);
+            } catch (ex) {}
+          }
 
           switch (property.type) {
             case 'integer':
@@ -1612,6 +1620,10 @@ class VirtualThingsAdapter extends Adapter {
 
           if (property.hasOwnProperty('multipleOf')) {
             prop.metadata.multipleOf = property.multipleOf;
+          }
+
+          if (property.hasOwnProperty('enum')) {
+            prop.metadata.enum = property.enum;
           }
 
           if (property.hasOwnProperty('readOnly')) {


### PR DESCRIPTION
This proposes adding an enum option for string properties, similar as min/max/multipleOf exist for numbers/integers.

I added this option as a string type, where one has to enter a valid JSON array (if no valid JSON is entered, not enum will be added to the property). I thought this may be helpful since one can just copy and paste the array from somewhere. But I think it may be more user-friendly to change the type to array of string?