### PR TITLE
Add custom actions to custom things

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,8 +40,7 @@
           "items": {
             "type": "object",
             "required": [
-              "name",
-              "properties"
+              "name"
             ],
             "properties": {
               "name": {
@@ -129,6 +128,38 @@
                     "default": {
                       "description": "Default value of this property. Use true/false for booleans.",
                       "type": "string"
+                    }
+                  }
+                }
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "title"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "Machine-readable action name, e.g. \"action1\".",
+                      "type": "string"
+                    },
+                    "title": {
+                      "description": "Human-readable action name, e.g. \"My Action 1\".",
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "Human-readable description of this action.",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Optional JSON describing the inputs of this action (No inputs if empty)",
+                      "type": "string"
+                    },
+                    "emitEvent": {
+                      "description": "Emit an event whenever this action gets executed",
+                      "type": "boolean"
                     }
                   }
                 }

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -1323,11 +1323,11 @@ class VirtualThingsDevice extends Device {
 
     action.start();
 
-    if (this.id.startsWith('virtual-things-custom-')){
+    if (this.id.startsWith('virtual-things-custom-')) {
       if (this.events.has(action.name)) {
         this.eventNotify(new Event(this,
-          action.name,
-          action.input));
+                                   action.name,
+                                   action.input));
       }
       action.finish();
       return Promise.resolve();
@@ -1642,7 +1642,7 @@ class VirtualThingsAdapter extends Adapter {
 
           newDescr.properties.push(prop);
         }
-        
+
         for (const action of actions) {
           const act = {
             name: action.name,


### PR DESCRIPTION
This proposes allowing for adding custom actions to custom things. They can be configured to raise an event of the same name as the property, setting the input (if present) as data. If one wants to have an input for the action, one currently has to write its JSON by onself. However, I could also add the input schema to the manifest (similar to properties), but this would then restrict it to inputs of type object and only one "level" of inputs. Thoughts?